### PR TITLE
chore: release without bot token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,18 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-
-    - uses: SocialGouv/actions/autodevops-release@v1
-      with:
-        author-name: ${{ secrets.SOCIALGROOVYBOT_NAME }}
-        author-email: ${{ secrets.SOCIALGROOVYBOT_EMAIL }}
-        github-token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
-
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "lts/*"
+      - name: Install additional semantic-release plugins
+        run: npm i --save=false semantic-release @socialgouv/releaserc @semantic-release/changelog @semantic-release/git @semantic-release/npm
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release --extends @socialgouv/releaserc


### PR DESCRIPTION
Utiliser la **deploy key** dans le secrets du repo plutôt que le PAT du Social Groovy bot